### PR TITLE
Fix the embedder name error in '__main__'

### DIFF
--- a/joerntools/SimplifiedAPIEmbedder.py
+++ b/joerntools/SimplifiedAPIEmbedder.py
@@ -125,6 +125,6 @@ class APIEmbedder(object):
         
 if __name__ == '__main__':
     import sys
-    embeder = APIEmbedder()
+    embedder = APIEmbedder()
     embedder.setOutputDirectory(sys.argv[1])
-    embeder.run()
+    embedder.run()


### PR DESCRIPTION
Fix the embedder name error in '__main__'. Sorry about the careless coding bug.